### PR TITLE
Разделитель ленты на прошлые и будущие события

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ nginx_rewrite.txt
 *.sublime-workspace
 .idea
 *.iml
+*.dump
 
 /config/database.yml
 /config/application.yml

--- a/app/assets/stylesheets/events.css.scss
+++ b/app/assets/stylesheets/events.css.scss
@@ -29,6 +29,26 @@
   }
 
   .events {
+    .upcoming-separator {
+      .type-label {
+        .arrow {
+          margin: 0;
+          padding-right: 10px;
+          float: left;
+        }
+        width: 300px;
+        margin: 0 auto;
+      }
+      margin-top: -20px;
+      padding: 20px 0;
+      hr {
+        border: 0.1em solid $gray-light;
+        margin: 20px 0;
+      }
+      h3 {
+        margin: 0;
+      }
+    }
     .event {
       &.panel {
         .panel-heading {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -11,7 +11,15 @@ class EventsController < ApplicationController
   has_scope :ordered_desc, type: :boolean, allow_blank: true, default: true
 
   def index
-    @events = apply_scopes(@events).decorate
+    @events = apply_scopes(@events)
+    first_upcoming_event = @events.upcoming.last
+    last_past_event = @events.past.first
+
+    if first_upcoming_event.present? && last_past_event.present?
+      @render_separator_after_id = first_upcoming_event.id
+    end
+
+    @events = @events.decorate
     respond_with @events
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -16,7 +16,8 @@ class Event < ActiveRecord::Base
   scope :ordered_desc, -> { order(started_at: :desc) }
   scope :published, -> { where(published: true) }
   scope :unpublished, -> { where(published: false) }
-  scope :upcomming, -> { where('started_at > ?', DateTime.current ) }
+  scope :upcoming, -> { where('started_at > ?', DateTime.current ) }
+  scope :past, -> { where('started_at <= ?', DateTime.current ) }
   scope :today, -> { started_in(DateTime.current) }
   scope :started_in, -> (datetime) {
     where('started_at > :start and started_at < :end',
@@ -39,7 +40,7 @@ class Event < ActiveRecord::Base
   end
 
   def past?
-    started_at < DateTime.current
+    started_at <= DateTime.current
   end
 
   def publish!

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -9,4 +9,23 @@
         i.fa.fa-calendar
     h1.pull-left = title Event.model_name.human(count: 2)
 
-  .events = render @events
+  .events
+    - @events.each do |event|
+
+      = render event
+
+      - if event.id == @render_separator_after_id
+        .upcoming-separator
+          .type-label
+            .arrow:h3
+              i.fa.fa-arrow-up
+            h3
+              = t('.upcoming_events')
+          hr
+          .type-label
+            .arrow:h3
+              i.fa.fa-arrow-down
+            h3
+              = t('.past_events')
+
+

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -117,6 +117,8 @@ ru:
       add_event_button_title: Добавить мероприятие
       rss_link_title: Лента мероприятий в формате RSS
       google_calendar_link_title: Google-календарь мероприятий
+      upcoming_events: Будущие события
+      past_events: Прошедшие события
     new:
       title: Новое мероприятие
     edit:

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -5,7 +5,7 @@ namespace :it61 do
   namespace :events do
     desc 'Отправить email-уведомления о мероприятиях опуликованных в течении вчерашнего дня'
     task new_events_digest: :environment do
-      events = Event.published.upcomming.published_in(1.day.ago).not_notified_about
+      events = Event.published.upcoming.published_in(1.day.ago).not_notified_about
       Rails.logger.info "No new events" and exit(0) if events.blank?
 
       Rails.logger.info "New events found: #{events.count}"
@@ -26,7 +26,7 @@ namespace :it61 do
     namespace :reminders do
       desc 'Отправить email-напопинания о предстоящем мероприятии пользователям, которые планируют его посетить'
       task email: :environment do
-        events = Event.published.upcomming.started_in(2.days.from_now)
+        events = Event.published.upcoming.started_in(2.days.from_now)
         events.each do |event|
           recipients = event.participants.notify_by_email
           recipients.each {|user| EventMailer.upcoming_event_reminder(user, event).deliver! }
@@ -36,7 +36,7 @@ namespace :it61 do
       desc 'Отправить sms-напопинания о предстоящем мероприятии пользователям, которые планируют его посетить'
       task sms: :environment do
         sms_sender = SmsSender::Epochta.new
-        Event.published.upcomming.today.each do |event|
+        Event.published.upcoming.today.each do |event|
           recipients = event.participants.notify_by_sms
           recipients.each {|user|
             text = I18n.translate('sms_sender.upcoming_event_reminder.body',

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     association :organizer, factory: :user
   end
 
-  trait :upcomming do
+  trait :upcoming do
     ignore do
       days_left { Forgery::Basic.number.days.since }
     end


### PR DESCRIPTION
Лента разделена на прошлые и будущие события, как предлагается в #51.

Выглвдит это так: 
![it](https://cloud.githubusercontent.com/assets/1252339/6966499/34133bd8-d962-11e4-8fe0-e89ffa6993a6.png)
