### PR TITLE
Add missing jQuery Serialize Object dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem "suspenders"
 gem "toastr-rails"
 gem "uglifier"
 gem "will_paginate"
+gem "jquery-serialize-object-rails"
 
 source "https://rails-assets.org" do
   gem "rails-assets-cropper"

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require jquery
 //= require jquery_ujs
+//= require jquery.serialize-object
 //= require toastr
 
 // Rails assets


### PR DESCRIPTION
When you add event the serializeObject function is used, which is not currently (see [this line](https://github.com/IT61/it61-rails/blob/master/app/assets/javascripts/events/event_manager.js#L43))
