### PR TITLE
Add meta title for about page

### DIFF
--- a/app/views/pages/about.html.slim
+++ b/app/views/pages/about.html.slim
@@ -1,3 +1,5 @@
+- title t("pages.about.link")
+
 .about-background
 .about-container
   .about-header


### PR DESCRIPTION
Сейчас нет собственного заголовка у страницы "О нас", поэтому может стоит его добавить, но исходя из контента страницы, лучше подошло бы название "Пожертвования", но так в меню страница представлена как "О нас", то и её мета-заголовок такой же, чтобы не нарушать единообразие.