### PR TITLE
mobile improvements 

### DIFF
--- a/app/assets/stylesheets/base/_typography.scss
+++ b/app/assets/stylesheets/base/_typography.scss
@@ -23,13 +23,13 @@ h6 {
 
 p {
   margin: 0 0 $small-spacing;
-  .text-content & { text-align: justify; }
 }
 
 a {
   color: $action-color;
   text-decoration: none;
   transition: color $base-duration $base-timing;
+  word-wrap: break-word;
 
   &:active,
   &:focus,

--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -24,6 +24,10 @@
 
   &-body {
     padding: 30px;
+
+    @include media(max-width 1000px) {
+      padding: 15px;
+    }
   }
 
   &-fold {


### PR DESCRIPTION
- убрал ужасное выравнивание по центру в текстовых блоках
- добавил перенос ссылок, до этого она отображалась в одну строку и на мобилке был горизонтальный скролл
- добавил медиаквери с меньшим паддингом для тела карточки
