### PR TITLE
Hide "Photos" menu item

### DIFF
--- a/app/views/application/_menu.html.slim
+++ b/app/views/application/_menu.html.slim
@@ -1,5 +1,5 @@
 = active_link_to t("pages.events"), events_path, wrap_tag: :li
 = active_link_to t("pages.users"), users_path, wrap_tag: :li
-= active_link_to t("pages.photos"), photos_path, wrap_tag: :li
+/= active_link_to t("pages.photos"), photos_path, wrap_tag: :li
 = active_link_to t("pages.about.link"), about_path, wrap_tag: :li
 li = link_to t("pages.slack"), Settings.community.link_to.slack, target: "_blank"


### PR DESCRIPTION
Instagram closed access to photos by tags.