### PR TITLE
Change cursor when mouse hover over the location link

### DIFF
--- a/app/assets/stylesheets/pages/_event_show.scss
+++ b/app/assets/stylesheets/pages/_event_show.scss
@@ -44,6 +44,7 @@
       padding-right: 25px;
 
       #map-trigger {
+        cursor: pointer;
         text-align: left;
         padding: 0;
       }


### PR DESCRIPTION
### tl;dr

<img src="http://i.imgur.com/DrQplxo.jpg" alt="before" width="300"/> → <img src="http://i.imgur.com/jkHoXMI.jpg" alt="after" width="300"/>


### explained

On the page with detailed event description there is a block with links:
* link to the speaker's social network account
* link to the event in a social network (like vk meeting)
* link to map

But actually the last item isn't a link, it's just a button which triggers a modal window.
It also doesn't have an `href` attribute, so chrome doesn't change cursor's type (to pointer).
This commit fixes this strange behaviour. Some people (including me) might be confused with it.

The better way to solve the problem is to handle requests like `it61.info/events/some-talk?map`, but this requires some SPA stuff.