### PR TITLE
Update Puma to fix Rails default boot port

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
     pry-rails (0.3.5)
       pry (>= 0.9.10)
     public_suffix (2.0.5)
-    puma (3.8.1)
+    puma (3.10.0)
     rack (2.0.2)
     rack-canonical-host (0.2.2)
       addressable (> 0, < 3)


### PR DESCRIPTION
Puma 3.8 has know bug which cause Rails server to start on port 9292 instead of 3000 (rails/rails#28971).

Possible solution is to explicitly specify exposed port with `-p 3000`, but updating Puma gem seems more reasonable.