### PR TITLE
Bump Docker image in Dockerfile to ruby:2.4.2

### DIFF
--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.1
+FROM ruby:2.4.2
 
 ENV APP_PATH=/app \
     BUNDLE_PATH=/gems


### PR DESCRIPTION
Ruby был обновлён до версии 2.4.2 в коммите  b39eb0543c070ecaf91e5638078f23f4e6a09248, но похоже что версия Docker образа также нужнается в обновлении.