### PR TITLE
Update nokogiri to 1.8.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       sass (>= 3.3)
     nenv (0.3.0)
     nio4r (2.2.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
     normalize-rails (3.0.3)
     oauth2 (1.3.1)
@@ -484,4 +484,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.2
+   1.16.3


### PR DESCRIPTION
Name: nokogiri
Version: 1.8.2
Advisory: CVE-2018-8048
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/pull/1746
Title: Revert libxml2 behavior in Nokogiri gem that could cause XSS
Solution: upgrade to >= 1.8.3