### PR TITLE
Fixed possibility of scrolling modal when heigh is grather than screen

### DIFF
--- a/app/assets/stylesheets/components/_modal.scss
+++ b/app/assets/stylesheets/components/_modal.scss
@@ -15,6 +15,7 @@
 
   .modal-fade-screen { // overlay
     @include position(fixed, 0 0 0 0);
+    overflow-y: auto;
     background-color: rgba(0, 0, 0, 0.6);
     opacity: 0;
     transition: opacity 0.25s ease;


### PR DESCRIPTION
Don't have possibility to click one of action buttons on macbook screen
![image](https://user-images.githubusercontent.com/17099950/61947210-4f879780-afad-11e9-97af-e406ef76fdf8.png)
